### PR TITLE
Allow isolated terminal handling

### DIFF
--- a/src/qetproject.py
+++ b/src/qetproject.py
@@ -385,10 +385,12 @@ class QETProject:
                     terminals = element.find('terminals').findall( 'terminal' )
                     terminalId = terminals[0].attrib['id']
                     cableNum = self._getCableNum(diagram, terminalId)
-                    terminalId2 = terminals[1].attrib['id']
-                    cableNum2 = self._getCableNum(diagram, terminalId2)
-                    if cableNum == '': cableNum = cableNum2
-                    
+                    try:
+                        terminalId2 = terminals[1].attrib['id']
+                        cableNum2 = self._getCableNum(diagram, terminalId2)
+                        if cableNum == '': cableNum = cableNum2
+                    except:
+                        pass
                     el['uuid'] = element.attrib['uuid']
                     el['block_name'] = terminalName.split(':')[0]
                     el['terminal_name'] = terminalName.split(':')[1]


### PR DESCRIPTION
DISCLAIMER: my python knowledge is close to zero!

I often use isolated terminals such `XT2:3` shown here:

![terminal-isolated](https://user-images.githubusercontent.com/160618/142868470-ddff70c4-3118-420f-82ac-6fb2afe23537.png)

This trigger the following error:
```
14:11:59 DEBUG    Getting cable number connected to terminal ...
Traceback (most recent call last):
  File "/usr/bin/qet_tb_generator", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3.9/site-packages/src/main.py", line 852, in main
    qet_project = QETProject(qet_file)  # allows working with a QET XML file.
  File "/usr/lib/python3.9/site-packages/src/qetproject.py", line 136, in __init__
    self._set_used_terminals()
  File "/usr/lib/python3.9/site-packages/src/qetproject.py", line 388, in _set_used_terminals
    terminalId2 = terminals[1].attrib['id']
IndexError: list index out of range
```
This patch just allows to have an undefined `terminals[1]` item. With that change in place, I'm able to use `qet_tb_generator` on my drawings.